### PR TITLE
add covr for test coverage

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,4 @@
 ^LICENSE\.md$
 ^README\.Rmd$
 ^\.travis\.yml$
+^codecov\.yml$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: R
 sudo: false
 cache: packages
+
+after_success:
+    - Rscript -e 'covr::codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,4 +22,5 @@ Imports:
     stringr,
     tidyr
 Suggests: 
-    testthat (>= 2.1.0)
+    testthat (>= 2.1.0),
+    covr

--- a/README.Rmd
+++ b/README.Rmd
@@ -4,7 +4,7 @@ output: github_document
 ---
 
 [![Travis build status](https://travis-ci.org/MethodsConsultants/tibbletest.svg?branch=master)](https://travis-ci.org/MethodsConsultants/tibbletest)
-
+[![Codecov test coverage](https://codecov.io/gh/MethodsConsultants/tibbletest/branch/master/graph/badge.svg)](https://codecov.io/gh/MethodsConsultants/tibbletest?branch=master)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ tibbletest
 
 [![Travis build
 status](https://travis-ci.org/MethodsConsultants/tibbletest.svg?branch=master)](https://travis-ci.org/MethodsConsultants/tibbletest)
+[![Codecov test
+coverage](https://codecov.io/gh/MethodsConsultants/tibbletest/branch/master/graph/badge.svg)](https://codecov.io/gh/MethodsConsultants/tibbletest?branch=master)
 
 ## Installation
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%


### PR DESCRIPTION
I'm assuming this has to be merged onto master to start showing up on codecov: https://codecov.io/gh/MethodsConsultants/tibbletest

All files changed/added from `usethis::use_coverage()`