### PR TITLE
allow original names to be passed into var_labels

### DIFF
--- a/R/preprocess.R
+++ b/R/preprocess.R
@@ -83,6 +83,12 @@ preprocess <- function(df, var_labels = NULL, clean_names = TRUE, convert_to_log
       df <- sjlabelled::set_label(df, snakecase::to_title_case(colnames(df)))
     }
   } else {
+    if (clean_names == TRUE) {
+      names(var_labels) <- var_labels %>%
+        names() %>%
+        janitor::make_clean_names()
+    }
+
     default_labels <- as.list(setNames(snakecase::to_title_case(colnames(df)), as.list(colnames(df))))
 
     labels <- default_labels %>%


### PR DESCRIPTION
I think this is all we need to allow `var_labels` to have either original or cleaned names. 